### PR TITLE
Publish v0.3.0 to JFrong NPM pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ test_env: &test_env
 publish_base: &publish_base
   <<: *build_base
   language: node_js
-  if: (type != cron) AND (branch == master)
+  if: (type == push) AND (branch == master)
   install:
   - rustc --version
   - cargo --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ build_base: &build_base
   before_install: # versions from https://github.com/erickt/rust-zmq/blob/master/.travis.yml
   - ./ci-scripts/install-zeromq.sh
 
-test_env: &test_env
+rust_build_base: &rust_build_base
   <<: *build_base
   language: rust
   os: linux
@@ -84,20 +84,20 @@ jobs:
   include:
   - stage: Build Test and Code Test
     name: Build Test (stable)
-    <<: *test_env
+    <<: *rust_build_base
     rust: stable
     if: (type != cron) AND (branch != staging.tmp) AND (branch != trying.tmp)
     script:
     - npm install
     - npm run build || travis_terminate 1
-  - <<: *test_env
+  - <<: *rust_build_base
     name: Build Test (nightly)
     rust: nightly
     if: (type != cron) AND (branch != staging.tmp) AND (branch != trying.tmp)
     script:
     - npm install
     - npm run build || travis_terminate 1
-  - <<: *test_env
+  - <<: *rust_build_base
     name: Code Test (stable)
     rust: stable
     if: (type != cron) AND (branch != staging.tmp) AND (branch != trying.tmp)
@@ -105,7 +105,7 @@ jobs:
     - npm install
     - npm run build:neon || travis_terminate 1
     - npm run test || travis_terminate 1
-  - <<: *test_env
+  - <<: *rust_build_base
     name: Code Test (nightly)
     rust: nightly
     if: (type != cron) AND (branch != staging.tmp) AND (branch != trying.tmp)
@@ -113,7 +113,7 @@ jobs:
     - npm install
     - npm run build:neon || travis_terminate 1
     - npm run test || travis_terminate 1
-  - <<: *test_env
+  - <<: *rust_build_base
     name: Lint and Audit
     if: (type != cron) AND (branch != staging.tmp) AND (branch != trying.tmp)
     script:
@@ -176,4 +176,12 @@ jobs:
     <<: *publish_job_windows
     os: windows
     node_js: 8
+  - stage: Push Artifact
+    <<: *rust_build_base
+    script:
+    - npm install
+    - curl -fL https://getcli.jfrog.io | sh
+    - ./jfrog rt config --url "$ARTIFACTORY_URL" --user "$ARTIFACTORY_USER" --password "$ARTIFACTORY_PASSWORD" --interactive=false &&
+      ./jfrog rt npmi --build-name=TravisCI --build-number=$TRAVIS_BUILD_NUMBER "$ARTIFACTORY_NAME" &&
+      ./jfrog rt npmp --build-name=TravisCI --build-number=$TRAVIS_BUILD_NUMBER "$ARTIFACTORY_NAME"
 


### PR DESCRIPTION
## 0.3.0 (Thaler Testnet v0.5)

### New features

- Introduce `toUnsignedHex()` method to staking account related transaction builders
- Introduce `toSignedPlainHex()` method to`WithdrawUnbondedTransactionBuilder`
- Introduce `compressedPublicKey` property to`KeyPair`

### Breaking Changes

- `cro.network.Devnet()` now requires fee configuration
- `cro.network.fromChainId()` now returns the chain enum instead of network configuration
- All transaction builders now use fee configuration defined in the network
- `WithdrawUnbondedTransactionBuilder` now accepts nonce and staking address instead of the whole staking state
- Staking account related transaction builders now accepts nonce in BigNumber (before it accepts a number)

### Bug FIxes

- Fixed transaction builders previously supported account nonce up to 2^16, now it accepts up to 2^32 through `BigNumber`
- Fixed `package.json` main is pointing to the wrong index file

### Internal Changes

- `WithdrawUnbondedTransactionBuilder` now no longer check for valid from validity and output amount validity because it no longer accepts staking state