### PR TITLE
Problem: Binary packaging job takes more than 30 mins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ publish_base: &publish_base
   - node -v
   - npm -v
   script:
-  - travis_wait 30 npm install
+  - travis_wait 60 npm install
   - npm run binary:publish
 publish_job: &publish_job
   <<: *publish_base


### PR DESCRIPTION
Solution: Extend binary packaging job timeout to 60 mins
